### PR TITLE
IO2019TEAM-63 Change endpoint definition to return a single object

### DIFF
--- a/src/main/resources/api.yaml
+++ b/src/main/resources/api.yaml
@@ -242,8 +242,7 @@ paths:
         200:
           description: Summary of requested sprint
           schema:
-            items:
-              $ref: '#/definitions/SprintSummaryDto'
+            $ref: '#/definitions/SprintSummaryDto'
 
 definitions:
   LoginResult:


### PR DESCRIPTION
GetSprintSummary should return a single object of SprintSummaryDto type