### PR TITLE
IO2019TEAM-100 Update sprint summary api to provide all needed values.

### DIFF
--- a/src/main/resources/SprintSummaryDto_field_meaning.md
+++ b/src/main/resources/SprintSummaryDto_field_meaning.md
@@ -1,0 +1,49 @@
+referencje do arkusza "Sprinty 1-*" w
+[Google Sheets](https://docs.google.com/spreadsheets/d/1doM61VumfUt55nClxNOFGWuj_AwKxchnaSgl8A_BZ-4/edit#gid=872062564)
+
+pola:
+
+L2: `prevAverageSprintCoefficient`
+backend, running average, cachowane
+
+L3: `startDate`
+backend, ze sprintDto, persystentne w sprint
+
+L4: `endDate`
+backend, ze sprintDto, persystentne w sprint
+
+L5: `timeToAssign = totalDeclaredTime / prevAverageSprintCoefficient`
+backend, nie persystentne
+
+L6-L12: `declaredTime[]`
+backend, z membersAvailabilityDto, persystentne w availability
+
+L13-L19: `effectiveDeclaredTime[] = declaredTime[] / prevAverageSprintCoefficient`
+backend, nie persystentne
+
+L20: `estimatedTimePlanned`
+podawany w dowolnym momencie w trakcie trwania sprintu
+backend, persystentne w sprint
+
+L21: `finalTimePlanned`
+podawany przy zamykaniu sprintu
+backend, persystentne w sprint
+
+L22: `timeBurned`
+podawany przy zamkykaniu sprintu
+backend, persystentne w sprint
+
+L23: `totalDeclaredTime = sum(declaredTime[])`
+backend, nie persystetne
+
+L24: `totalNeededTime = coefficient * finalTimePlanned`
+backend, nie persystentne
+
+L25: `coefficient = totalDeclaredTime / timeBurned`
+wyliczane przy zamykaniu sprintu
+backend, persystentne w sprint
+
+L26: `currentAverageSprintCoefficient`
+backend, running average, cachowane
+
+`timeRemaining` i `estimatedTimePlanned` nie wpływają na obliczenia i są jedynie poglądowe

--- a/src/main/resources/api.yaml
+++ b/src/main/resources/api.yaml
@@ -522,10 +522,17 @@ components:
           description: The amount of time burned throughout the sprint (in minutes)
           type: integer
           format: int64
-        timePlanned:
-          description: The amount of time planned for the sprint (in minutes)
+        estimatedTimePlanned:
+          description: The amount of time initially planned for the sprint (in minutes)
           type: integer
           format: int64
+        finalTimePlanned:
+          description: The amount of actual time planned for the sprint (in minutes)
+          type: integer
+          format: int64
+        coefficient:
+          type: number
+          format: double
         sprintState:
           $ref: '#/components/schemas/SprintStateDto'
       required:
@@ -579,6 +586,10 @@ components:
           type: integer
           format: int64
           description: In minutes
+        effectiveTimeAvailable:
+          type: integer
+          format: int64
+          description: In minutes
         timeRemaining:
           type: integer
           format: int64
@@ -592,22 +603,36 @@ components:
     SprintSummaryDto:
       type: object
       properties:
+        sprint:
+          $ref: '#/components/schemas/SprintDto'
         membersAvailability:
           type: array
           items:
             $ref: '#/components/schemas/UserAvailabilityDto'
           description: List of members' availability for given sprint
-        totalAvailableTime:
+        prevAverageSprintCoefficient:
+          type: number
+          format: double
+        currentAverageSprintCoefficient:
+          type: number
+          format: double
+        timeToAssign:
           type: integer
           format: int64
           description: In minutes
-        sprintCoefficient:
-          type: number
-          format: double
+        totalDeclaredTime:
+          type: integer
+          format: int64
+          description: In minutes
+        totalNeededTime:
+          type: integer
+          format: int64
+          description: In minutes
       required:
+        - sprint
         - membersAvailability
-        - totalAvailableTime
-        - sprintCoefficient
+        - prevAverageSprintCoefficient
+        - totalDeclaredTime
 
     UserAvailabilityDto:
       type: object


### PR DESCRIPTION
referencje do arkusza "Sprinty 1-*" w
https://docs.google.com/spreadsheets/d/1doM61VumfUt55nClxNOFGWuj_AwKxchnaSgl8A_BZ-4/edit#gid=872062564

pola:

L2:      `prevAverageSprintCoefficient`
    backend, running average, cachowane

L3:      `startDate`
    backend, ze sprintDto, persystentne w sprint

L4:      `endDate`
    backend, ze sprintDto, persystentne w sprint

L5:      `timeToAssign = totalDeclaredTime / prevAverageSprintCoefficient`
    backend, nie persystentne
    
L6-L12:  `declaredTime[]`
    backend, z membersAvailabilityDto, persystentne w availability

L13-L19: `effectiveDeclaredTime[] = declaredTime[] / prevAverageSprintCoefficient`
    backend, nie persystentne
    
L20:     `estimatedTimePlanned`
    podawany w dowolnym momencie w trakcie trwania sprintu
    backend, persystentne w sprint

L21:     `finalTimePlanned`
    podawany przy zamykaniu sprintu
    backend, persystentne w sprint

L22:     `timeBurned`
    podawany przy zamkykaniu sprintu
    backend, persystentne w sprint

L23:     `totalDeclaredTime = sum(declaredTime[])`
    backend, nie persystetne

L24:     `totalNeededTime = coefficient * finalTimePlanned`
    backend, nie persystentne

L25:     `coefficient = totalDeclaredTime / timeBurned`
    wyliczane przy zamykaniu sprintu
    backend, persystentne w sprint

L26:     `currentAverageSprintCoefficient`
    backend, running average, cachowane


timeRemaining wydaje się nie wpływać na obliczenia
jedynie jest skorelowany z obliczaniem timeBurned ale
nie jest to cos co mozemy wykorzystac w automatyzacji
bo musielibysmy sie cofac w czasie do poprzedniego sprintu
dlatego timeBurned jest specyfikowany przy zamykaniu
